### PR TITLE
Declare variable key in the get_user example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ def get_user(self, user_id):
     if user is None:
         user = db.query("SELECT * FROM users WHERE user_id = {0}", user_id)
         if user is not None:
+            key = "user.{0}".format(user_id)
             cache.set(key, json.dumps(user))
     return user
 ```


### PR DESCRIPTION
As the variable `key` is not defined, the example could generate a little of confusion in my opinion.

If we don't want to add more complexity using `format()`, we should be also able to just do `key = "user.{user_id}`.