### PR TITLE
Change AP wording for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Waiting for a response from the partitioned node might result in a timeout error
 
 #### AP - availability and partition tolerance
 
-Responses return the most recent version of the data, which might not be the latest.  Writes might take some time to propagate when the partition is resolved.
+Responses return the most recent version of the data available on the a node, which might not be the latest.  Writes might take some time to propagate when the partition is resolved.
 
 AP is a good choice if the business needs allow for [eventual consistency](#eventual-consistency) or when the system needs to continue working despite external errors.
 


### PR DESCRIPTION
I think that the description for AP should be changed. It currently says that the most recent version of the data might not be the latest. 
The explanation of Consistency uses the same word, recent. 
I have changed AP to qualify 'recent' as being the most recent data available on the node