### PR TITLE
Fix reducer argument in pastebin exercise

### DIFF
--- a/solutions/system_design/pastebin/README.md
+++ b/solutions/system_design/pastebin/README.md
@@ -218,7 +218,7 @@ class HitCounts(MRJob):
         period = self.extract_year_month(line)
         yield (period, url), 1
 
-    def reducer(self, key, value):
+    def reducer(self, key, values):
         """Sum values for each key.
 
         (2016-01, url0), 2


### PR DESCRIPTION
This should make it clear that the code the developer writes for the reduce steps indeed gets an iterable of values, not only a single value.

That's how the [luigi mapreduce framework](https://github.com/spotify/luigi/blob/710e7238406a9843945c74d53f5524a6284194f0/examples/wordcount_hadoop.py#L84) is designed at least.