### PR TITLE
Add automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+dist: trusty
+language: python
+python:
+    - 2.7.13
+    - 3.6.1
+install:
+    - pip install flake8
+script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The goal of this change is to have Travis-CI automatically run [flake8](http://flake8.readthedocs.io) tests on every pull request. This will help contributors know if their submissions are going to *break the build*. To turn on this **free** service, you would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started/