### PR TITLE
Add missing colons to class methods

### DIFF
--- a/solutions/object_oriented_design/lru_cache/lru_cache.py
+++ b/solutions/object_oriented_design/lru_cache/lru_cache.py
@@ -29,7 +29,7 @@ class Cache(object):
         self.lookup = {}  # key: query, value: node
         self.linked_list = LinkedList()
 
-    def get(self, query)
+    def get(self, query):
         """Get the stored query result from the cache.
 
         Accessing a node updates its position to the front of the LRU list.

--- a/solutions/system_design/query_cache/query_cache_snippets.py
+++ b/solutions/system_design/query_cache/query_cache_snippets.py
@@ -52,7 +52,7 @@ class Cache(object):
         self.lookup = {}
         self.linked_list = LinkedList()
 
-    def get(self, query)
+    def get(self, query):
         """Get the stored query result from the cache.
 
         Accessing a node updates its position to the front of the LRU list.


### PR DESCRIPTION
Without these colons, these lines are syntax errors.  Discovered via #93