### PR TITLE
Add missing enum imports

### DIFF
--- a/solutions/object_oriented_design/online_chat/online_chat.py
+++ b/solutions/object_oriented_design/online_chat/online_chat.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+from enum import Enum
 
 
 class UserService(object):

--- a/solutions/system_design/mint/mint_snippets.py
+++ b/solutions/system_design/mint/mint_snippets.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from enum import Enum
+
+
 class DefaultCategories(Enum):
 
     HOUSING = 0
     FOOD = 1
     GAS = 2
     SHOPPING = 3
-    ...
+    # ...
+
 
 seller_category_map = {}
 seller_category_map['Exxon'] = DefaultCategories.GAS
@@ -44,4 +48,3 @@ class Budget(object):
 
     def override_category_budget(self, category, amount):
         self.categories_to_budget_map[category] = amount
-


### PR DESCRIPTION
Resolve the _undefined name_ __Enum__ in two files by importing it from [__enum__](https://docs.python.org/3/library/enum.html).  Also fix a Syntax Error.

flake8 testing of https://github.com/donnemartin/system-design-primer on Python 3.6

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./solutions/object_oriented_design/online_chat/online_chat.py:98:21: F821 undefined name 'Enum'
class RequestStatus(Enum):
                    ^
./solutions/system_design/mint/mint_snippets.py:3:25: F821 undefined name 'Enum'
class DefaultCategories(Enum):
                        ^
2    F821 undefined name 'Enum'
2
```