### PR TITLE
Change variable seller to category in Mint solution

### DIFF
--- a/solutions/system_design/mint/mint_mapreduce.py
+++ b/solutions/system_design/mint/mint_mapreduce.py
@@ -30,7 +30,7 @@ class SpendingByCategory(MRJob):
         (2016-01, shopping), 100
         (2016-01, gas), 50
         """
-        timestamp, seller, amount = line.split('\t')
+        timestamp, category, amount = line.split('\t')
         period = self. extract_year_month(timestamp)
         if period == self.current_year_month():
             yield (period, category), amount


### PR DESCRIPTION
In the current code, __seller__ is an unused variable and __category__ is an undefined name (see #93).

Given that the class is __SpendingByCategory__, this PR advocates changing seller —> category.