### PR TITLE
Clarification around wide column stores and traditional column stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,16 +997,18 @@ Document stores provide high flexibility and are often used for working with occ
 
 A wide column store's basic unit of data is a column (name/value pair).  A column can be grouped in column families (analogous to a SQL table).  Super column families further group column families.  You can access each column independently with a row key, and columns with the same row key form a row.  Each value contains a timestamp for versioning and for conflict resolution.
 
-Google introduced [Bigtable](http://www.read.seas.harvard.edu/~kohler/class/cs239-w08/chang06bigtable.pdf) as the first wide column store, which influenced the open-source [HBase](https://www.mapr.com/blog/in-depth-look-hbase-architecture) often-used in the Hadoop ecosystem, and [Cassandra](http://docs.datastax.com/en/cassandra/3.0/cassandra/architecture/archIntro.html) from Facebook.  Stores such as BigTable, HBase, and Cassandra maintain keys in lexicographic order, allowing efficient retrieval of selective key ranges.
+Google introduced [Bigtable](http://www.read.seas.harvard.edu/~kohler/class/cs239-w08/chang06bigtable.pdf) as the first wide column store, which influenced the open-source [HBase](https://www.mapr.com/blog/in-depth-look-hbase-architecture) often-used in the Hadoop ecosystem, and [Cassandra](http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architectureIntro_c.html) from Facebook.  Stores such as BigTable, HBase, and Cassandra maintain keys in lexicographic order, allowing efficient retrieval of selective key ranges.
 
 Wide column stores offer high availability and high scalability.  They are often used for very large data sets.
+
+Note that wide column stores are different from [column stores](https://en.wikipedia.org/wiki/Column-oriented_DBMS), which more closely resemble traditional RDBMS.
 
 ##### Source(s) and further reading: wide column store
 
 * [SQL & NoSQL, a brief history](http://blog.grio.com/2015/11/sql-nosql-a-brief-history.html)
 * [Bigtable architecture](http://www.read.seas.harvard.edu/~kohler/class/cs239-w08/chang06bigtable.pdf)
 * [HBase architecture](https://www.mapr.com/blog/in-depth-look-hbase-architecture)
-* [Cassandra architecture](http://docs.datastax.com/en/cassandra/3.0/cassandra/architecture/archIntro.html)
+* [Cassandra architecture](http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architectureIntro_c.html)
 
 #### Graph database
 


### PR DESCRIPTION
Small clarification (initially had some confusion around this / wished something nudged in the right direction). 

I was also hoping to get someone else's thoughts on something. I found the wide column store graphic a little unintuitive, so I looked for an alternative and found [this](https://www.google.com/search?q=wide+column+store&sa=X&rlz=1C5CHFA_enUS762US762&biw=1440&bih=803&tbm=isch&source=iu&ictx=1&fir=CxYrUGrU0LibKM%253A%252C_HcNDK9zQiUdLM%252C_&usg=AFrqEzdzSoFTLW06EWU9G_4bax4N0V9isw&ved=2ahUKEwjgibP5z8XdAhX_IjQIHT5NBDMQ9QEwBnoECAMQBA#imgrc=uMLQM9L8MkyJQM:), which I thought was a little clearer. It's not a great standalone image, but there's a nice way I could link to it? (E.g., Maybe just include a link with the text "Alternative diagram"?)