### PR TITLE
Fix broken SQL link in Scaling AWS exercise

### DIFF
--- a/solutions/system_design/scaling_aws/README.md
+++ b/solutions/system_design/scaling_aws/README.md
@@ -83,7 +83,7 @@ Handy conversion guide:
 
 * **Web server** on EC2
     * Storage for user data
-    * [**MySQL Database**](https://github.com/donnemartin/system-design-primer#sql)
+    * [**MySQL Database**](https://github.com/donnemartin/system-design-primer#relational-database-management-system-rdbms)
 
 Use **Vertical Scaling**:
 


### PR DESCRIPTION
There is no anchor for #sql on the README page, so I changed it to the most related topic #relational-database-management-system-rdbms