### PR TITLE
Use epub-metadata option

### DIFF
--- a/generate-epub.sh
+++ b/generate-epub.sh
@@ -6,7 +6,7 @@ generate_from_stdin() {
 
   echo "Generating '$language' ..."
 
-  pandoc --metadata-file=epub-metadata.yaml --metadata=lang:$2 --from=markdown -o $1 <&0
+  pandoc --epub-metadata=epub-metadata.yaml --metadata=lang:$2 --from=markdown -o $1 <&0
 
   echo "Done! You can find the '$language' book at ./$outfile"
 }


### PR DESCRIPTION
Use epub-metadata option for pandoc to consume metadata file. The previous option --metadata-fie is probably outdated.