### PR TITLE
Fix typo: Change replication to federation

### DIFF
--- a/solutions/system_design/web_crawler/README.md
+++ b/solutions/system_design/web_crawler/README.md
@@ -282,7 +282,7 @@ Some searches are very popular, while others are only executed once.  Popular qu
 
 Below are a few other optimizations to the **Crawling Service**:
 
-* To handle the data size and request load, the **Reverse Index Service** and **Document Service** will likely need to make heavy use sharding and replication.
+* To handle the data size and request load, the **Reverse Index Service** and **Document Service** will likely need to make heavy use sharding and federation.
 * DNS lookup can be a bottleneck, the **Crawler Service** can keep its own DNS lookup that is refreshed periodically
 * The **Crawler Service** can improve performance and reduce memory usage by keeping many open connections at a time, referred to as [connection pooling](https://en.wikipedia.org/wiki/Connection_pool)
     * Switching to [UDP](https://github.com/donnemartin/system-design-primer#user-datagram-protocol-udp) could also boost performance


### PR DESCRIPTION
I believe there's a typo in here and it should say "federation" as opposed to "replication" as replication does not solve the problem of data size and request load.