### PR TITLE
Fix: metadata-file

### DIFF
--- a/generate-epub.sh
+++ b/generate-epub.sh
@@ -6,7 +6,7 @@ generate_from_stdin() {
 
   echo "Generating '$language' ..."
 
-  pandoc --metadata-file=epub-metadata.yaml --metadata=lang:$2 --from=markdown -o $1 <&0
+  pandoc --epub-metadata=epub-metadata.yaml --metadata=lang:$2 --from=markdown -o $1 <&0
 
   echo "Done! You can find the '$language' book at ./$outfile"
 }


### PR DESCRIPTION
I have tried to run generate-epub.sh script on my ubuntu 20.04 and pandoc 2.2.3.2
It failed with error no option metadata-file.
I found from man-page that epub-metadata works and tested it 
It generated all the epub files .