### PR TITLE
changed user_id size from 32 bytes to 8 bytes

### DIFF
--- a/solutions/system_design/twitter/README.md
+++ b/solutions/system_design/twitter/README.md
@@ -66,7 +66,7 @@ Search
 
 * Size per tweet:
     * `tweet_id` - 8 bytes
-    * `user_id` - 32 bytes
+    * `user_id` - 8 bytes
     * `text` - 140 bytes
     * `media` - 10 KB average
     * Total: ~10 KB


### PR DESCRIPTION
I think user_id should be 8 bytes, not 32 bytes, later down on the page for Redis list, it is also defined as 8 bytes.