### PR TITLE
add git action for generating epub and upload artifacts

### DIFF
--- a/.github/workflows/generate-epub.yml
+++ b/.github/workflows/generate-epub.yml
@@ -1,0 +1,18 @@
+name: Generate Epub
+on: [push,pull_request]
+jobs:
+  generate-epub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Installing Pandoc
+        run: sudo apt-get install pandoc
+      - name: Generating Epub
+        run: ./generate-epub.sh
+        shell: bash
+      - name: Uploading Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: system-design-primer-epubs
+          path: ./*.epub


### PR DESCRIPTION
Too frequently we use mobile/tab to read in our spare time, generating epub in mobile/tab is not something that we like to do. We can generate it on a computer and send it to mobile/tab for sure, but that adds some extra friction.

This MR aims to generate epub in GitHub Linux server and upload epubs as artifacts. Artifact stays on the GitHub server for 90 days, not too bad!

Artifacts will be accessible from the `Actions` page.