### PR TITLE
Update broken Palantir system design interview link to archive.org permalink

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -276,7 +276,7 @@
 
 以下のリンク先ページを見てどのような質問を投げかけられるか概要を頭に入れておきましょう:
 
-* [システム設計面接で成功するには？](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [システム設計面接で成功するには？](https://web.archive.org/web/20210505130322/https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
 * [システム設計面接](http://www.hiredintech.com/system-design)
 * [アーキテクチャ、システム設計面接への導入](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -280,7 +280,7 @@
 
 查看下面的链接以获得我们期望的更好的想法：
 
-* [怎样通过一个系统设计的面试](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [怎样通过一个系统设计的面试](https://web.archive.org/web/20210505130322/https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
 * [系统设计的面试](http://www.hiredintech.com/system-design)
 * [系统架构与设计的面试简介](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -276,7 +276,7 @@
 
 查看以下的連結獲得更好的做法：
 
-* [如何在系統設計的面試中勝出](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [如何在系統設計的面試中勝出](https://web.archive.org/web/20210505130322/https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
 * [系統設計的面試](http://www.hiredintech.com/system-design)
 * [系統架構與設計的面試介紹](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ You might be asked to do some estimates by hand.  Refer to the [Appendix](#appen
 
 Check out the following links to get a better idea of what to expect:
 
-* [How to ace a systems design interview](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [How to ace a systems design interview](https://web.archive.org/web/20210505130322/https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
 * [The system design interview](http://www.hiredintech.com/system-design)
 * [Intro to Architecture and Systems Design Interviews](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 * [System design template](https://leetcode.com/discuss/career/229177/My-System-Design-Template)


### PR DESCRIPTION
Fixes #567 

Palantir system design interview page is archived at archive.org; using that instead.