### PR TITLE
Update GitHub Engineer Blog link

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1712,7 +1712,7 @@ Notes
 * [Facebook Engineering](https://www.facebook.com/Engineering)
 * [Flickr Code](http://code.flickr.net/)
 * [Foursquare Engineering Blog](http://engineering.foursquare.com/)
-* [GitHub Engineering Blog](http://githubengineering.com/)
+* [GitHub Engineering Blog](https://github.blog/category/engineering)
 * [Google Research Blog](http://googleresearch.blogspot.com/)
 * [Groupon Engineering Blog](https://engineering.groupon.com/)
 * [Heroku Engineering Blog](https://engineering.heroku.com/)

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -1723,7 +1723,7 @@ Notes
 * [Facebook Engineering](https://www.facebook.com/Engineering)
 * [Flickr Code](http://code.flickr.net/)
 * [Foursquare Engineering Blog](http://engineering.foursquare.com/)
-* [GitHub Engineering Blog](http://githubengineering.com/)
+* [GitHub Engineering Blog](https://github.blog/category/engineering)
 * [Google Research Blog](http://googleresearch.blogspot.com/)
 * [Groupon Engineering Blog](https://engineering.groupon.com/)
 * [Heroku Engineering Blog](https://engineering.heroku.com/)

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -1713,7 +1713,7 @@ Notes
 * [Facebook Engineering](https://www.facebook.com/Engineering)
 * [Flickr Code](http://code.flickr.net/)
 * [Foursquare Engineering Blog](http://engineering.foursquare.com/)
-* [GitHub Engineering Blog](http://githubengineering.com/)
+* [GitHub Engineering Blog](https://github.blog/category/engineering)
 * [Google Research Blog](http://googleresearch.blogspot.com/)
 * [Groupon Engineering Blog](https://engineering.groupon.com/)
 * [Heroku Engineering Blog](https://engineering.heroku.com/)

--- a/README.md
+++ b/README.md
@@ -1764,7 +1764,7 @@ Handy metrics based on numbers above:
 * [Facebook Engineering](https://www.facebook.com/Engineering)
 * [Flickr Code](http://code.flickr.net/)
 * [Foursquare Engineering Blog](http://engineering.foursquare.com/)
-* [GitHub Engineering Blog](http://githubengineering.com/)
+* [GitHub Engineering Blog](https://github.blog/category/engineering)
 * [Google Research Blog](http://googleresearch.blogspot.com/)
 * [Groupon Engineering Blog](https://engineering.groupon.com/)
 * [Heroku Engineering Blog](https://engineering.heroku.com/)


### PR DESCRIPTION
As of today, the newest article of https://githubengineering.com and https://github.blog/category/engineering were from 2019/03/05 and 2021/10/06 respectively. Not sure what happened to https://githubengineering.com , but https://github.blog/category/engineering seems to be more up to date.

| https://githubengineering.com | https://github.blog/category/engineering |
| --- | --- |
| <img width="969" alt="image" src="https://user-images.githubusercontent.com/12410942/136699074-a45047ca-c9c9-449f-a2ca-25e30adddc6e.png"> | <img width="990" alt="image" src="https://user-images.githubusercontent.com/12410942/136699084-125548b6-28df-4e49-b80b-c01a34c48666.png"> |
