### PR TITLE
Fix the translation wrong

### DIFF
--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -739,7 +739,7 @@ CDN 拉取是当第一个用户请求该资源时，从服务器上拉取资源�
 
 ### 微服务
 
-与此讨论相关的话题是 [微服务](https://en.wikipedia.org/wiki/Microservices)，可以被描述为一系列可以独立部署的小型的，模块化服务。每个服务运行在一个独立的线程中，通过明确定义的轻量级机制通讯，共同实现业务目标。<sup><a href=https://smartbear.com/learn/api-design/what-are-microservices>1</a></sup>
+与此讨论相关的话题是 [微服务](https://en.wikipedia.org/wiki/Microservices)，可以被描述为一系列可以独立部署的小型的，模块化服务。每个服务运行在一个独立的进程中，通过明确定义的轻量级机制通讯，共同实现业务目标。<sup><a href=https://smartbear.com/learn/api-design/what-are-microservices>1</a></sup>
 
 例如，Pinterest 可能有这些微服务： 用户资料、关注者、Feed 流、搜索、照片上传等。
 


### PR DESCRIPTION
原文:

> Related to this discussion are microservices, which can be described as a suite of independently deployable, small, modular services. Each service runs a unique **process** and communicates through a well-defined, lightweight mechanism to serve a business goal.

将 process 翻译为线程是一个明显的错误，并可能造成困扰，为了清楚地表示微服务是不同的程序，这里应该翻译为 进程
