### PR TITLE
Typo in Twitter solution

### DIFF
--- a/solutions/system_design/twitter/README.md
+++ b/solutions/system_design/twitter/README.md
@@ -66,7 +66,7 @@ Search
 
 * Size per tweet:
     * `tweet_id` - 8 bytes
-    * `user_id` - 32 bytes
+    * `user_id` - 8 bytes
     * `text` - 140 bytes
     * `media` - 10 KB average
     * Total: ~10 KB


### PR DESCRIPTION
`user_id` should be 8bytes, 2<sup>64</sup>-1 values ~ 2<sup>)10</sup><sup>)2</sup><sup>)3</sup> ~ 1mn<sup>3</sup> values is more than enough for userID (2<sup>10</sup> = 1024 ~ 1000).