### PR TITLE
en: Fixed issue #816 - Updated the URL for Elasticache caching strategy in README.md [English version]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1318,7 +1318,7 @@ Refresh-ahead can result in reduced latency vs read-through if the cache can acc
 * [Introduction to architecting systems for scale](http://lethain.com/introduction-to-architecting-systems-for-scale/)
 * [Scalability, availability, stability, patterns](http://www.slideshare.net/jboner/scalability-availability-stability-patterns/)
 * [Scalability](http://www.lecloud.net/post/9246290032/scalability-for-dummies-part-3-cache)
-* [AWS ElastiCache strategies](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Strategies.html)
+* [AWS ElastiCache strategies](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Strategies.html)
 * [Wikipedia](https://en.wikipedia.org/wiki/Cache_(computing))
 
 ## Asynchronism


### PR DESCRIPTION
Fixed #816 

Changes:
Updated the URL for Elasticache caching strategies from [http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Strategies.html] to [https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Strategies.html] in the README.md file.

Reason for Change:
The previous URL pointing to Elasticache caching strategies was outdated. The new URL directs users to the most recent and accurate documentation provided by AWS.

- [x] Review the Contributing Guidelines
- [x] It meets all requirements in the [Contributing Guidelines]
- [x] Tagged the [language maintainer] @donnemartin
- [x] Prefixed the title with a language code


