### PR TITLE
Fixes How to ace a systems design interview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ You might be asked to do some estimates by hand.  Refer to the [Appendix](#appen
 
 Check out the following links to get a better idea of what to expect:
 
-* [How to ace a systems design interview](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [How to ace a systems design interview](https://web.archive.org/web/20190103232449/http://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview)
 * [The system design interview](http://www.hiredintech.com/system-design)
 * [Intro to Architecture and Systems Design Interviews](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 * [System design template](https://leetcode.com/discuss/career/229177/My-System-Design-Template)


### PR DESCRIPTION
Fixes How to ace a systems design interview link by linking to Web archive instead.
