### PR TITLE
fix: Replace broken sd interview link with archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ You might be asked to do some estimates by hand.  Refer to the [Appendix](#appen
 
 Check out the following links to get a better idea of what to expect:
 
-* [How to ace a systems design interview](https://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
+* [How to ace a systems design interview](https://archive.ph/LP4Yx/)
 * [The system design interview](http://www.hiredintech.com/system-design)
 * [Intro to Architecture and Systems Design Interviews](https://www.youtube.com/watch?v=ZgdS0EUmn70)
 * [System design template](https://leetcode.com/discuss/career/229177/My-System-Design-Template)


### PR DESCRIPTION
Original link seems to be broken so I replaced it with an archived version of the site.
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/5499c92d-37e4-44b3-85d1-c01d4f13148a" />
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/5c074f67-15ba-4d4d-a567-50f5277639e5" />
