### PR TITLE
Fix AttributeError in LRU cache eviction (missing query on Node)

### DIFF
--- a/solutions/object_oriented_design/lru_cache/lru_cache.py
+++ b/solutions/object_oriented_design/lru_cache/lru_cache.py
@@ -1,8 +1,17 @@
 class Node(object):
 
-    def __init__(self, results):
+    def __init__(self, query, results):
+        """Doubly-linked list node used by the LRU cache.
+
+        Args:
+            query: The cache key this node represents.
+            results: Cached value for *query*.
+        """
+        self.query = query
         self.results = results
-        self.next = next
+        # Pointers for the doubly-linked list
+        self.prev = None
+        self.next = None
 
 
 class LinkedList(object):
@@ -61,6 +70,6 @@ class Cache(object):
             else:
                 self.size += 1
             # Add the new key and value
-            new_node = Node(results)
+            new_node = Node(query, results)
             self.linked_list.append_to_front(new_node)
             self.lookup[query] = new_node


### PR DESCRIPTION
Fix AttributeError in LRU cache eviction (missing `query` on [Node](cci:2://file:///c:/Users/T2430514/Downloads/system-design-primer/solutions/object_oriented_design/lru_cache/lru_cache.py:0:0-4:24))

### Description
The sample LRU cache crashes on eviction because [Node](cci:2://file:///c:/Users/T2430514/Downloads/system-design-primer/solutions/object_oriented_design/lru_cache/lru_cache.py:0:0-4:24) instances lack a
`query` attribute, yet `Cache.set()` references `tail.query` when removing the
oldest item.  
Added `query` (and minor docs) to [Node](cci:2://file:///c:/Users/T2430514/Downloads/system-design-primer/solutions/object_oriented_design/lru_cache/lru_cache.py:0:0-4:24) and create nodes with both key and
value, eliminating the runtime error and restoring cache functionality.