### PR TITLE
Fix bug in Cache.set(): self.map[query] is not defined in constructor, replaced with self.lookup.get(query)

### DIFF
--- a/solutions/system_design/query_cache/query_cache_snippets.py
+++ b/solutions/system_design/query_cache/query_cache_snippets.py
@@ -71,7 +71,7 @@ class Cache(object):
         If the entry is new and the cache is at capacity, removes the oldest entry
         before the new entry is added.
         """
-        node = self.map[query]
+        node = self.lookup.get(query)
         if node is not None:
             # Key exists in cache, update the value
             node.results = results


### PR DESCRIPTION
### Previous Code
```python
class Cache(object):

    def __init__(self, MAX_SIZE):
        self.MAX_SIZE = MAX_SIZE
        self.size = 0
        self.lookup = {}
        self.linked_list = LinkedList()

    def set(self, results, query):
        node = self.map[query]        
```
In the set function:
`self.map[query]` was used to retrieve query but it is not defined in the constructor.
So I replaced it with `self.lookup.get(query)` to correctly do that based on the constructor.