### PR TITLE
Fix broken link in README "NGINX architecture"

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Load balancers can also help with horizontal scaling, improving performance and 
 
 ### Source(s) and further reading
 
-* [NGINX architecture](https://www.nginx.com/blog/inside-nginx-how-we-designed-for-performance-scale/)
+* [NGINX architecture](https://blog.nginx.org/blog/inside-nginx-how-we-designed-for-performance-scale)
 * [HAProxy architecture guide](http://www.haproxy.org/download/1.2/doc/architecture.txt)
 * [Scalability](https://web.archive.org/web/20220530193911/https://www.lecloud.net/post/7295452622/scalability-for-dummies-part-1-clones)
 * [Wikipedia](https://en.wikipedia.org/wiki/Load_balancing_(computing))


### PR DESCRIPTION
Now pointing correctly to https://blog.nginx.org/blog/inside-nginx-how-we-designed-for-performance-scale