### PR TITLE
en: link fixed for push and pull CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ AP is a good choice if the business needs to allow for [eventual consistency](#e
 
 ### Source(s) and further reading
 
-* [CAP theorem revisited](https://robertgreiner.com/cap-theorem-revisited/))
+* [CAP theorem revisited](https://robertgreiner.com/cap-theorem-revisited/)
 * [A plain english introduction to CAP theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem)
 * [CAP FAQ](https://github.com/henryr/cap-faq)
 * [The CAP theorem](https://www.youtube.com/watch?v=k-Yaq8AHlFA)
@@ -654,7 +654,7 @@ Sites with heavy traffic work well with pull CDNs, as traffic is spread out more
 ### Source(s) and further reading
 
 * [Globally distributed content delivery](https://figshare.com/articles/Globally_distributed_content_delivery/6605972)
-* [The differences between push and pull CDNs](http://www.travelblogadvice.com/technical/the-differences-between-push-and-pull-cdns/)
+* [The differences between push and pull CDNs](https://www.geeksforgeeks.org/system-design/pull-cdn-vs-push-cdn/)
 * [Wikipedia](https://en.wikipedia.org/wiki/Content_delivery_network)
 
 ## Load balancer


### PR DESCRIPTION
This PR replaces the link for pulling/pushing CDNs

Also removed an extra char not required in one of the lines.
