### PR TITLE
docs: correct cache terminology (evict vs invalidate) and update invalidation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ Your database usually includes some level of caching in a default configuration,
 
 ### Application caching
 
-In-memory caches such as Memcached and Redis are key-value stores between your application and your data storage.  Since the data is held in RAM, it is much faster than typical databases where data is stored on disk.  RAM is more limited than disk, so [cache invalidation](https://en.wikipedia.org/wiki/Cache_algorithms) algorithms such as [least recently used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) can help invalidate 'cold' entries and keep 'hot' data in RAM.
+In-memory caches such as Memcached and Redis are key-value stores between your application and your data storage.  Since the data is held in RAM, it is much faster than typical databases where data is stored on disk.  RAM is more limited than disk, so [cache eviction](https://en.wikipedia.org/wiki/Cache_algorithms) algorithms such as [least recently used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) can help evict 'cold' entries and keep 'hot' data in RAM.
 
 Redis has the following additional features:
 
@@ -1307,7 +1307,7 @@ Refresh-ahead can result in reduced latency vs read-through if the cache can acc
 
 ### Disadvantage(s): cache
 
-* Need to maintain consistency between caches and the source of truth such as the database through [cache invalidation](https://en.wikipedia.org/wiki/Cache_algorithms).
+* Need to maintain consistency between caches and the source of truth such as the database through [cache invalidation](https://en.wikipedia.org/wiki/Cache_invalidation).
 * Cache invalidation is a difficult problem, there is additional complexity associated with when to update the cache.
 * Need to make application changes such as adding Redis or memcached.
 


### PR DESCRIPTION
In the 'Application caching' section, I changed 'invalidate' to 'evict' when referring to LRU. LRU is an eviction policy (managing capacity/space), whereas invalidation refers to data consistency (truth). Additionally, I updated the Wikipedia link in the 'Disadvantages' section to point to 'Cache_invalidation' instead of 'Cache_replacement_policies' to align the link with the context of data consistency.