### PR TITLE
Fix 'Design a key-value store like Redis' link to point to design resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1655,7 +1655,7 @@ Handy metrics based on numbers above:
 | Design a search engine like Google | [queue.acm.org](http://queue.acm.org/detail.cfm?id=988407)<br/>[stackexchange.com](http://programmers.stackexchange.com/questions/38324/interview-question-how-would-you-implement-google-search)<br/>[ardendertat.com](http://www.ardendertat.com/2012/01/11/implementing-search-engines/)<br/>[stanford.edu](http://infolab.stanford.edu/~backrub/google.html) |
 | Design a scalable web crawler like Google | [quora.com](https://www.quora.com/How-can-I-build-a-web-crawler-from-scratch) |
 | Design Google docs | [code.google.com](https://code.google.com/p/google-mobwrite/)<br/>[neil.fraser.name](https://neil.fraser.name/writing/sync/) |
-| Design a key-value store like Redis | [slideshare.net](http://www.slideshare.net/dvirsky/introduction-to-redis) |
+| Design a key-value store like Redis | [codecapsule.com](http://codecapsule.com/2012/11/07/ikvs-implementing-a-key-value-store-table-of-contents/)<br/>[allthingsdistributed.com](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf) |
 | Design a cache system like Memcached | [slideshare.net](http://www.slideshare.net/oemebamo/introduction-to-memcached) |
 | Design a recommendation system like Amazon's | [hulu.com](https://web.archive.org/web/20170406065247/http://tech.hulu.com/blog/2011/09/19/recommendation-system.html)<br/>[ijcai13.org](http://ijcai13.org/files/tutorial_slides/td3.pdf) |
 | Design a tinyurl system like Bitly | [n00tc0d3r.blogspot.com](http://n00tc0d3r.blogspot.com/) |


### PR DESCRIPTION
## Summary

Fixes #291

The "Design a key-value store like Redis" row in the **Additional System Design Interview Questions** table linked to [Introduction to Redis](http://www.slideshare.net/dvirsky/introduction-to-redis) on SlideShare — a general introduction to Redis, not a resource about designing/architecting a distributed key-value store.

This PR replaces that link with two design-focused references:

- **[Implementing a Key-Value Store](http://codecapsule.com/2012/11/07/ikvs-implementing-a-key-value-store-table-of-contents/)** (codecapsule.com) — A detailed article series covering the architecture and implementation of a key-value store from scratch
- **[Amazon Dynamo Paper](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf)** (allthingsdistributed.com) — The foundational paper on designing a highly available distributed key-value store

The "Introduction to Redis" link in the **Company architectures/technologies** table (line 1708) is intentionally preserved, as it appropriately references Redis as a technology in that context.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*