### PR TITLE
Fix broken Redis architecture link

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -965,7 +965,7 @@ NoSQL は **key-value store**、 **document-store**、 **wide column store**、 
 
 * [キーバリューデータベース](https://en.wikipedia.org/wiki/Key-value_database)
 * [キーバリューストアの欠点](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redisアーキテクチャ](https://redis.io/tutorials/what-is-redis/)
+* [Redisアーキテクチャ](https://redis.io/docs/latest/integrate/redis-data-integration/architecture/)
 * [メムキャッシュアーキテクチャ](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### ドキュメントストア

--- a/README-ja.md
+++ b/README-ja.md
@@ -965,7 +965,7 @@ NoSQL は **key-value store**、 **document-store**、 **wide column store**、 
 
 * [キーバリューデータベース](https://en.wikipedia.org/wiki/Key-value_database)
 * [キーバリューストアの欠点](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redisアーキテクチャ](http://qnimate.com/overview-of-redis-architecture/)
+* [Redisアーキテクチャ](https://redis.io/tutorials/what-is-redis/)
 * [メムキャッシュアーキテクチャ](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### ドキュメントストア

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -976,7 +976,7 @@ NoSQL 是**键-值数据库**、**文档型数据库**、**列型数据库**或*
 
 - [键-值数据库](https://en.wikipedia.org/wiki/Key-value_database)
 - [键-值存储的劣势](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-- [Redis 架构](http://qnimate.com/overview-of-redis-architecture/)
+- [Redis 架构](https://redis.io/tutorials/what-is-redis/)
 - [Memcached 架构](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### 文档类型存储

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -976,7 +976,7 @@ NoSQL 是**键-值数据库**、**文档型数据库**、**列型数据库**或*
 
 - [键-值数据库](https://en.wikipedia.org/wiki/Key-value_database)
 - [键-值存储的劣势](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-- [Redis 架构](https://redis.io/tutorials/what-is-redis/)
+- [Redis 架构](https://redis.io/docs/latest/integrate/redis-data-integration/architecture/)
 - [Memcached 架构](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### 文档类型存储

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -966,7 +966,7 @@ NoSQL 指的是 **鍵-值對的資料庫**、**文件類型資料庫**、**列�
 
 * [鍵值對資料庫](https://en.wikipedia.org/wiki/Key-value_database)
 * [鍵值對資料庫的缺點](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redis 架構](http://qnimate.com/overview-of-redis-architecture/)
+* [Redis 架構](https://redis.io/tutorials/what-is-redis/)
 * [Memcached 架構](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### 文件類型資料庫

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -966,7 +966,7 @@ NoSQL 指的是 **鍵-值對的資料庫**、**文件類型資料庫**、**列�
 
 * [鍵值對資料庫](https://en.wikipedia.org/wiki/Key-value_database)
 * [鍵值對資料庫的缺點](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redis 架構](https://redis.io/tutorials/what-is-redis/)
+* [Redis 架構](https://redis.io/docs/latest/integrate/redis-data-integration/architecture/)
 * [Memcached 架構](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### 文件類型資料庫

--- a/README.md
+++ b/README.md
@@ -1014,7 +1014,7 @@ A key-value store is the basis for more complex systems such as a document store
 
 * [Key-value database](https://en.wikipedia.org/wiki/Key-value_database)
 * [Disadvantages of key-value stores](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redis architecture](http://qnimate.com/overview-of-redis-architecture/)
+* [Redis architecture](https://redis.io/tutorials/what-is-redis/)
 * [Memcached architecture](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### Document store

--- a/README.md
+++ b/README.md
@@ -1014,7 +1014,7 @@ A key-value store is the basis for more complex systems such as a document store
 
 * [Key-value database](https://en.wikipedia.org/wiki/Key-value_database)
 * [Disadvantages of key-value stores](http://stackoverflow.com/questions/4056093/what-are-the-disadvantages-of-using-a-key-value-table-over-nullable-columns-or)
-* [Redis architecture](https://redis.io/tutorials/what-is-redis/)
+* [Redis architecture](https://redis.io/docs/latest/integrate/redis-data-integration/architecture/)
 * [Memcached architecture](https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
 
 #### Document store


### PR DESCRIPTION
## Summary

- Replaces the dead qnimate.com Redis architecture URL with Redis official architecture documentation.
- Updates the same broken link in the English, Japanese, Simplified Chinese, and Traditional Chinese READMEs.

Fixes #1060.

## Validation

- Confirmed `http://qnimate.com/overview-of-redis-architecture/` no longer resolves.
- Confirmed `https://redis.io/docs/latest/integrate/redis-data-integration/architecture/` returns HTTP 200.