### PR TITLE
Add link to an interactive companion site (#1363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Check out the sister repo [**Interactive Coding Challenges**](https://github.com
 
 * [Coding deck](https://github.com/donnemartin/interactive-coding-challenges/tree/master/anki_cards/Coding.apkg)
 
+## Interactive companion
+
+Prefer this guide as a browsable site?  [**system-design-primer.rujalduwal.com.np**](https://system-design-primer.rujalduwal.com.np) presents these sections with their own URLs, full-text search across the guide, and interactive simulations of the trade-offs they describe.  Community-maintained, free, and open source ([source](https://github.com/Rujal-Duwal/system-design-primer-web)).
+
 ## Contributing
 
 > Learn from the community.


### PR DESCRIPTION
Answers the request in #1363 for a browsable version of the guide.

**https://system-design-primer.rujalduwal.com.np**

I offered this on the issue and am opening the PR as promised. It is a
one-section, additive change — happy to move it, shrink it, or close this
if a link here is not wanted.

*(Supersedes #1378, which I closed by accident while fixing the wording — same
six-line change.)*

### What the site adds

- Each of the guide's sections gets **its own URL**, so a single topic can be linked or bookmarked. That was the actual request in #1363.
- **Full-text search** across the guide and the solution write-ups.
- **Interactive simulations** of six of the trade-offs the guide describes — you build a system against a budget and an SLO, run traffic through it, and watch which component saturates.

### Why it should not go stale

This is the part I would want to be convinced of if I were reviewing it.

The site does **not** copy the text. A build step fetches this repo's `README.md`
and the `solutions/system_design/*` files, parses them, and rebuilds the pages
from source. If a heading anchor disappears upstream, that build **fails** rather
than silently dropping a section. Every page shows which parts are this repo's
text and which are the site's own summaries, along with the date it last synced.

Content is used under CC BY 4.0 with attribution to you on every page.

### Disclosure

I built and host the site, so this is a link to my own work. It is free, has no
ads, no tracking beyond cookieless page counts, and asks nothing of the reader.
The [source](https://github.com/Rujal-Duwal/system-design-primer-web) is public
under MIT, with the content remaining CC BY 4.0.

Entirely understand if you would rather not carry a third-party link — no hard
feelings either way, and the site will keep working regardless.
